### PR TITLE
Create range syntax: 1-3$$

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ You can also use the same wildcard twice
 
 This will randomly combine two of the options for every batch, separated with a comma.  In this case, "opt1, opt2" or "opt2, opt3", or "opt1, opt3" or the same pairs in the reverse order.
 
-The prefix `2$$` can use any number between 1 and the total number of options you defined. If you omit the size prefix, then 1 will be used
+	{1-3$$opt1|opt2|opt3}
+
+This will use a random number of options between 1 and 3 for each batch. 
+
+	{opt1|opt2|opt3}
+If you omit the $$ prefix, one item will be selected. (Equivalent to 1$$)
 
 ### Wildcard files
 Wildcard files are not provided by this script as lists exists in other repositories. A good place to start looking is [here](https://github.com/jtkelm2/stable-diffusion-webui-1/tree/master/scripts/wildcards)

--- a/dynamic_prompting.py
+++ b/dynamic_prompting.py
@@ -14,7 +14,7 @@ from modules.shared import opts
 logger = logging.getLogger(__name__)
 
 WILDCARD_DIR = getattr(opts, "wildcard_dir", "scripts/wildcards")
-VERSION = 0.2
+VERSION = 0.3
 
 re_wildcard = re.compile(r"__([^_]*)__")
 re_combinations = re.compile(r"\{([^{}]*)}")

--- a/dynamic_prompting.py
+++ b/dynamic_prompting.py
@@ -93,20 +93,11 @@ def pick_variant(template):
             In this case, "opt1" or "opt2" or "opt3"
 
         Combinations
-            [2$$opt1|opt2|opt3] : will randomly combine 2 of the options for every batch, separated with a comma
+            {2$$opt1|opt2|opt3} : will randomly combine 2 of the options for every batch, separated with a comma
 
             In this case, "opt1, opt2" or "opt2, opt3", or "opt1, opt3" or the same pairs in the reverse order.
-
-            The prefix (2$$) can use any number between 1 and the total number of options you defined
-
-            NB : if you omit the size prefix, the number of options combined will be defined randomly
-
-        Nesting
-            You can have variations inside combinations but not the other way round (for now)
-
-            Example:
-
-            I love[ {red|white} wine | {layered|chocolate} cake | {german|belgian} beer]
+            
+            {1-3$$opt1|opt2|opt3} : will combine a random number of options between 1 and 3 for every batch
     """
     if template is None:
         return None
@@ -127,6 +118,10 @@ class Script(scripts.Script):
             Choose a number of terms from a list, in this case we choose two artists
             <code>{{2$$artist1|artist2|artist3}}</code>
             If $$ is not provided, then 1$$ is assumed.
+            <br>
+            A range can be provided:
+            <code>{{1-3$$artist1|artist2|artist3}}</code>
+            In this case, a random number of artists between 1 and 3 is chosen.
             <br/><br/>
 
             <h3><strong>Wildcards</strong></h3>

--- a/dynamic_prompting.py
+++ b/dynamic_prompting.py
@@ -29,19 +29,27 @@ def replace_combinations(match):
     variants = [s.strip() for s in match.groups()[0].split("|")]
     if len(variants) > 0:
         first = variants[0].split("$$")
-        num = DEFAULT_NUM_COMBINATIONS
-        if len(first) == 2:
-            num, first_variant = first
+        quantity = DEFAULT_NUM_COMBINATIONS
+        if len(first) == 2: # there is a $$
+            prefix_num, first_variant = first
             variants[0] = first_variant
+            
             try:
-                num = int(num)
-            except ValueError:
-                logger.warning("Unexpected combination formatting, expected $$ prefix to be a number")
-                num = DEFAULT_NUM_COMBINATIONS
+                prefix_ints = [int(i) for i in prefix_num.split("-")]
+                if len(prefix_ints) == 1:
+                    quantity = prefix_ints[0]
+                elif len(prefix_ints) == 2:
+                    prefix_low, prefix_high = prefix_ints
+                    quantity = random.randint(prefix_low, prefix_high)
+                else:
+                    raise Exception
+            except:
+                logger.warning("Unexpected combination formatting, expected $$ prefix to be a number or interval")
+                # quantity is default (DEFAULT_NUM_COMBINATIONS = 1)
         
         try:
-            picked = random.sample(variants, num)
-            return ",".join(picked)
+            picked = random.sample(variants, quantity)
+            return ", ".join(picked)
         except ValueError as e:
             logger.exception(e)
             return ""

--- a/dynamic_prompting.py
+++ b/dynamic_prompting.py
@@ -39,7 +39,8 @@ def replace_combinations(match):
                 if len(prefix_ints) == 1:
                     quantity = prefix_ints[0]
                 elif len(prefix_ints) == 2:
-                    prefix_low, prefix_high = prefix_ints
+                    prefix_low = min(prefix_ints)
+                    prefix_high = max(prefix_ints)
                     quantity = random.randint(prefix_low, prefix_high)
                 else:
                     raise Exception


### PR DESCRIPTION
This PR includes a new feature where the number of choices is random from a provided range.
It extends the quantity syntax (`3$$`) to optionally include a lower and upper bound (`1-3$$`).
The quantity of choices is randomly, uniformly selected from the interval including both bounds for each batch.
0 is a valid lower bound.

This PR also adds spaces between prompts (previously `{2$$a|b}` would return `a,b` instead of `a, b`). This has an impact on tokenization and may improve results (not tested).

Documentation is updated and obsolete inline documentation (for nesting) is removed.

Version is bumped to 0.3.