### PR TITLE
Scan wildcard directory recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ if the 3rd row is chosen, then either Autumn or Fall will be selected. You could
 	{Autumn|Fall}
 	Spring
 
+## Fuzzy Glob/recursive wildcard file/directory matching
+In addition to standard wildcard tokens such as `__times__` -> `times.txt`, you can also use globbing to match against multiple files at once.
+`*` can be used to specify an arbitrary contiguous part of a path
+  * e.g. `__settings*manmade__` will match `settings/indoor/manmade/` (and everything under that directory) and/or `settings/outdoor/manmade.txt`, but will _not_ match settings/outdoor/natural`, etc.
+
+You can also use slashes to specify paths to match against.
+  * e.g. `__fav/chars__` will match `fav/chars.txt` and/or all files under the directory `fav/chars/` 
 
 ## WILDCARD_DIR
 The script looks for wildcard files in WILDCARD_DIR. This is defined in the main webui config.json under wildcard_dir. If wildcard_dir is missing, then wildcard files should be placed in scripts/wildcards/

--- a/dynamic_prompting.py
+++ b/dynamic_prompting.py
@@ -142,10 +142,10 @@ class Script(scripts.Script):
 
             <h3><strong>Wildcards</strong></h3>
             <p>Available wildcards</p>
-            <ul>
+            <ul style="overflow-y:auto;max-height:6rem;">
         """
         
-        for path in Path(WILDCARD_DIR).glob("*.txt"):
+        for path in Path(WILDCARD_DIR).rglob("*.txt"):
             filename = path.name
             wildcard = "__" + filename.replace(".txt", "") + "__"
 

--- a/dynamic_prompting.py
+++ b/dynamic_prompting.py
@@ -146,7 +146,7 @@ class Script(scripts.Script):
         """
         
         for path in Path(WILDCARD_DIR).rglob("*.txt"):
-            filename = path.name
+            filename = str(path.relative_to(WILDCARD_DIR))
             wildcard = "__" + filename.replace(".txt", "") + "__"
 
             html += f"<li>{wildcard}</li>"


### PR DESCRIPTION
# Recursive wildcard scanning
Resolves #12
The primary intent of this PR is to allow the script to recursively scan the wildcards directory, which would allow users to organize their wildcards with file structures of arbitrary depth.

To ensure the listed wildcards continue to represent full paths of now arbitrary depth, we also change the return value from `path.name` to `path.relative_to(WILDCARD_DIR)`

This should not effect existing wildcards, as we previously didn't support any depth.
New entries will only having leading path elements if they exist in a subdirectory of any depth under `WILDCARD_DIR`

![image](https://user-images.githubusercontent.com/1847524/197535036-08f0526b-c2eb-4cec-85f7-889bf42f0f2f.png)

___
## Controversial additions
I wanted to mention these items before this is merged in case we want to omit or break them out.

### Wildcard globbing as explained here: https://github.com/evanjs/sd-dynamic-prompting/tree/extended-glob#fuzzy-globrecursive-wildcard-filedirectory-matching
This is not crucial to the recursive scanning which is core to this pull request, and we can probably omit without much issue.
Source: https://github.com/evanjs/sd-dynamic-prompting/blob/7e9f7d1edce0cd38b8effee0a4b44b9220188466/dynamic_prompting.py#L80-L87

### Ignoring lines that start with a leading `#`
I found this a useful way to persist wildcards while being able to easily disable anything that doesn't work well until it can later be addressed. At the same time, I can see how it might cause issues if there exists wildcards that start with `#`, such as hashtags, etc.
Source: https://github.com/evanjs/sd-dynamic-prompting/blob/7e9f7d1edce0cd38b8effee0a4b44b9220188466/dynamic_prompting.py#L94-L95.

### Replace underscore option for danbooru tag compatiblity
Tags from danbooru use underscores rather than spaces as a word separator.
This option provides an easy way to source native Danbooru tags without first manually replacing every underscore with a space.