### PR TITLE
Folders for organization 

### DIFF
--- a/dynamic_prompting.py
+++ b/dynamic_prompting.py
@@ -152,8 +152,9 @@ class Script(scripts.Script):
             border-right-style: solid;
             border-top-style: solid;
             border-left-style: solid;
-            border-radius: 8px 8px 0px 0px;
-            padding: 3px;
+            border-bottom-style: solid;
+            border-radius: 8px 8px 8px 8px;
+            padding: 5px;
             margin-top: 10px;
             text-align: left;
             outline: none;

--- a/dynamic_prompting.py
+++ b/dynamic_prompting.py
@@ -113,39 +113,107 @@ def generate_prompt(template):
             logger.info(f"Prompt: {prompt}")
             return prompt
         old_prompt = prompt
-        
+
+def getTxt(dir):
+    temp = ""
+    temp += f"<button type=\"button\" class=\"collapsible\">{dir.name} :</button>"
+    temp += f"<div class=\"content\">"
+    for path in Path(dir).glob("*.txt"):
+        filename = path.name
+        wildcard = "&emsp;__" + dir.name + "." + filename.replace(".txt", "") + "__"
+
+        temp += f"<li>{wildcard}</li>"
+    temp += f"</div>"
+    return temp
+
+def probe(dir):
+    temp = ""
+    for path in Path(dir).iterdir():
+        if path.is_dir():
+            temp += getTxt(path)
+
+    return temp
+
 class Script(scripts.Script):
     def title(self):
         return f"Dynamic Prompting v{VERSION}"
 
     def ui(self, is_img2img):
-        html = f"""
+
+        html = """
+            <style>
+            .collapsible {
+            background-color: #1f2937;
+            color: white;
+            cursor: pointer;
+            padding: 18px;
+            width: 100%;
+            border: 2px #0C111C;
+            border-right-style: solid;
+            border-top-style: solid;
+            border-left-style: solid;
+            border-radius: 8px 8px 0px 0px;
+            padding: 3px;
+            margin-top: 10px;
+            text-align: left;
+            outline: none;
+            font-size: 15px;
+            }
+
+            .active, .collapsible:hover {
+            background-color: #555;
+            }
+
+            .codeblock {
+                background-color: #06080D;
+            }
+
+            .content {
+            padding: 0 18px;
+            display: none;
+            overflow: hidden;
+            border: 2px #0C111C;
+            border-right-style: solid;
+            border-bottom-style: solid;
+            border-left-style: solid;
+            border-radius: 0px 0px 8px 8px;
+            background-color: #1f2937;
+            }
+            </style>
+        """
+
+        html += f"""
+            <h3><strong>Note</strong></h3>
+            Folder depth is only <strong>1</strong>!!
+            Folders add organization when having multiple wildcards.<br>
+            Wildcards txt documents need to be in a folder, example:<br>
+            &emsp;&#x2022; Correct: <code class="codeblock">scripts/wildcards/&#60;folder&#62;/*.txt</code><br>
+            &emsp;&#x2022; Incorrect: <code class="codeblock">scripts/wildcards/*.txt</code><br>
+            If the groups wont drop down click <strong onclick="check_collapsibles()" style="cursor: pointer">here</strong> to fix the issue.
+            <br/><br/>
+            <h3><strong>Syntax</strong></h3>
+            In order to use a wildcard the prefix must be a folder name: 
+            <code class="codeblock">__&#60;folder&#62;.wildcard__</code>, example:
+            <code class="codeblock">__sd.wildcard__</code><br>
+            The folder name will be provided in the dropdowns.
+            <br/><br/>
             <h3><strong>Combinations</strong></h3>
-            Choose a number of terms from a list, in this case we choose two artists
-            <code>{{2$$artist1|artist2|artist3}}</code>
+            Choose a number of terms from a list, in this case we choose two artists: 
+            <code class="codeblock">{{2$$artist1|artist2|artist3}}</code>
             If $$ is not provided, then 1$$ is assumed.
-            <br>
             A range can be provided:
-            <code>{{1-3$$artist1|artist2|artist3}}</code>
+            <code class="codeblock">{{1-3$$artist1|artist2|artist3}}</code>
             In this case, a random number of artists between 1 and 3 is chosen.
             <br/><br/>
-
             <h3><strong>Wildcards</strong></h3>
-            <p>Available wildcards</p>
-            <ul style="overflow-y:auto;max-height:6rem;">
         """
         
-        for path in Path(WILDCARD_DIR).rglob("*.txt"):
-            filename = str(path.relative_to(WILDCARD_DIR))
-            wildcard = "__" + filename.replace(".txt", "") + "__"
-
-            html += f"<li>{wildcard}</li>"
-
-        html += "</ul>"
+        html += probe(WILDCARD_DIR)
+        NEW_WILDCARD_DIR = WILDCARD_DIR.replace("/wildcards", "/wildcards/&#60;folder&#62;")
         html += f"""
-            <br/>
-            <code>WILDCARD_DIR: {WILDCARD_DIR}</code><br/>
-            <small>You can add more wildcards by creating a text file with one term per line and name is mywildcards.txt. Place it in {WILDCARD_DIR}. <code>__mywildcards__</code> will then become available.</small>
+            <br/><br/>
+            <code class="codeblock">WILDCARD_DIR: {NEW_WILDCARD_DIR}</code><br/>
+            <small>You can add more wildcards by creating a text file with one term per line and name is mywildcards.txt. Place it in {NEW_WILDCARD_DIR}. <code class="codeblock">__&#60;folder&#62;.mywildcards__</code> will then become available.</small>
         """
         info = gr.HTML(html)
         return [info]

--- a/dynamic_prompting.py
+++ b/dynamic_prompting.py
@@ -16,6 +16,7 @@ logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 
 WILDCARD_DIR = getattr(opts, "wildcard_dir", "scripts/wildcards")
+FOLDER_COUNT = len(str(Path(WILDCARD_DIR)).split(os.sep))
 MAX_RECURSIONS = 20
 VERSION = "0.6.0"
 WILDCARD_SUFFIX = "txt"
@@ -64,16 +65,15 @@ class WildcardManager:
     def join_wildcard(self, path) -> str():
         split = (str(path).split(os.sep))
         additional_char = ""
-        if len(split) > 3:
+        if len(split) > FOLDER_COUNT + 1:
             additional_char = "/"
-        #print(str(split) +" - "+str(len(split)))
-        return "/".join(split[2:-1])+additional_char
+        return "/".join(split[FOLDER_COUNT:-1])+additional_char
 
     def join_directory(self, path) -> str():
-        return "/".join((str(path).split(os.sep))[2:])
+        return "/".join((str(path).split(os.sep))[FOLDER_COUNT:])
 
     def get_current_folder(self, dir) -> list():
-        return sorted(list(pathlib.Path(dir).glob('*/')))
+        return list(pathlib.Path(dir).glob('*/'))
 
     def match_files(self, wildcard:str) -> list():
         return [

--- a/dynamic_prompting.py
+++ b/dynamic_prompting.py
@@ -62,13 +62,18 @@ class WildcardManager:
         return files
     
     def join_wildcard(self, path) -> str():
-        return "/".join((str(path).split(os.sep))[2:-1])
+        split = (str(path).split(os.sep))
+        additional_char = ""
+        if len(split) > 3:
+            additional_char = "/"
+        #print(str(split) +" - "+str(len(split)))
+        return "/".join(split[2:-1])+additional_char
 
     def join_directory(self, path) -> str():
         return "/".join((str(path).split(os.sep))[2:])
 
     def get_current_folder(self, dir) -> list():
-        return list(pathlib.Path(dir).glob('*/'))
+        return sorted(list(pathlib.Path(dir).glob('*/')))
 
     def match_files(self, wildcard:str) -> list():
         return [
@@ -92,7 +97,7 @@ class UiCreation:
     def write_txt(self, path):
         temp = ""
         filename = path.name
-        wildcard = "__" + wildcard_manager.join_wildcard(path) + "/" + filename.replace(".txt", "") + "__"
+        wildcard = "__" + wildcard_manager.join_wildcard(path) + filename.replace(".txt", "") + "__"
 
         temp += f"<p>{wildcard}</p>"
         return temp

--- a/dynamic_prompting.py
+++ b/dynamic_prompting.py
@@ -71,11 +71,15 @@ def replace_wildcard(match):
         wildcard_dir.mkdir()
 
     wildcard = match.groups()[0]
-    txt_files = list(pathlib.Path(wildcard_dir).rglob("*.txt"))
+    folder = str(wildcard).split(".")[0]
 
+    newWildcardDir = str(wildcard_dir).replace("\\wildcards", f"\\wildcards\\{folder}")
+
+    txt_files = list(pathlib.Path(newWildcardDir).rglob("*.txt"))
     replacement_files = []
     for path in txt_files:
-        if wildcard in str(path.absolute()) or os.path.normpath(wildcard) in str(path.absolute()):
+        absolute = str(path.absolute()).replace("\\", ".")
+        if wildcard in absolute or os.path.normpath(wildcard) in absolute:
             replacement_files.append(str(path.absolute()))
 
     contents: Set = set()

--- a/dynamic_prompting.py
+++ b/dynamic_prompting.py
@@ -60,6 +60,15 @@ class WildcardManager:
             files = [f.relative_to(self._path) for f in files]
 
         return files
+    
+    def join_wildcard(self, path) -> str():
+        return "/".join((str(path).split(os.sep))[2:-1])
+
+    def join_directory(self, path) -> str():
+        return "/".join((str(path).split(os.sep))[2:])
+
+    def get_current_folder(self, dir) -> list():
+        return list(pathlib.Path(dir).glob('*/'))
 
     def match_files(self, wildcard:str) -> list():
         return [
@@ -71,6 +80,8 @@ class WildcardManager:
         wildcards = [f"__{path.with_suffix('')}__" for path in files]
         return wildcards
 
+wildcard_manager = WildcardManager()
+
 class UiCreation:
     def write(self, path):
         if path.is_dir():
@@ -81,32 +92,31 @@ class UiCreation:
     def write_txt(self, path):
         temp = ""
         filename = path.name
-        wildcard = "__" + "/".join((str(path).split("\\"))[2:-1])+ "/" + filename.replace(".txt", "") + "__"
+        wildcard = "__" + wildcard_manager.join_wildcard(path) + "/" + filename.replace(".txt", "") + "__"
 
         temp += f"<p>{wildcard}</p>"
         return temp
 
     def write_dir(self, path):
         temp = ""
-        Ppath = "/".join(str(path).split("\\")[2:])
-        temp += f"<button type=\"button\" class=\"collapsible\">{Ppath} :</button>"
+        joined_path = wildcard_manager.join_directory(path)
+        temp += f"<button type=\"button\" class=\"collapsible\">{joined_path} :</button>"
         temp += f"<div class=\"content\">"
         
-        for file_or_dir in list(pathlib.Path(path).glob('*/')):
+        for file_or_dir in wildcard_manager.get_current_folder(path):
             temp += self.write(file_or_dir)
 
         temp += f"</div>"
         return temp 
 
-    def probe(self, dir):
+    def probe(self):
         temp = ""
-        directories = list(pathlib.Path(dir).glob('*/')) #.rglob("*txt")
-        for dirs in directories[0:]:
-            temp += self.write(dirs)
+        files = wildcard_manager.get_current_folder(WILDCARD_DIR)# #.rglob("*txt")
+        for file in files[0:]:
+            temp += self.write(file)
         return temp
 
 ui_creation = UiCreation()
-wildcard_manager = WildcardManager()
 
 def replace_combinations(match):
     if match is None or len(match.groups()) == 0:
@@ -253,7 +263,7 @@ class Script(scripts.Script):
         """
         
         #wildcards = wildcard_manager.get_wildcards()
-        html += ui_creation.probe(WILDCARD_DIR) #"".join([f"<li>{wildcard}</li>" for wildcard in wildcards])
+        html += ui_creation.probe() #"".join([f"<li>{wildcard}</li>" for wildcard in wildcards])
 
         html += f"""
             <br/><br/>

--- a/javascript/dynamic_prompting.js
+++ b/javascript/dynamic_prompting.js
@@ -1,0 +1,18 @@
+onUiUpdate(function(){
+  check_collapsibles();
+})
+
+function check_collapsibles() {
+  var coll = gradioApp().querySelectorAll(".collapsible")
+  for (var i = 0; i < coll.length; i++) {
+    coll[i].addEventListener("click", function() {
+      this.classList.toggle("active");
+      var content = this.nextElementSibling;
+      if (content.style.display === "block") {
+        content.style.display = "none";
+      } else {
+        content.style.display = "block";
+      }
+    });
+  }
+}

--- a/javascript/dynamic_prompting.js
+++ b/javascript/dynamic_prompting.js
@@ -10,8 +10,12 @@ function check_collapsibles() {
       var content = this.nextElementSibling;
       if (content.style.display === "block") {
         content.style.display = "none";
+        this.style.borderBottomStyle = "solid";
+        this.style.borderRadius = "8px"
       } else {
         content.style.display = "block";
+        this.style.borderBottomStyle = "none";
+        this.style.borderRadius = "8px 8px 0px 0px"
       }
     });
   }


### PR DESCRIPTION
Support folders in the `scripts/wildcards`

Added info
```
Note
Folder depth is only 1!! Folders add organization when having multiple wildcards.
Wildcards txt documents need to be in a folder, example:
 • Correct: scripts/wildcards/<folder>/*.txt
 • Incorrect: scripts/wildcards/*.txt
If the groups wont drop down click here to fix the issue.

Syntax
In order to use a wildcard the prefix must be a folder name: __<folder>.wildcard__, example: __sd.wildcard__
The folder name will be provided in the dropdowns. 
```
Added `javascript/dynamic_prompting.js` for the dropout

Wildcard are displayed in groups(folders), the dropout names are the folder names in `scripts/wildcards/`

![firefox_JBzzLuJHV7](https://user-images.githubusercontent.com/38667368/197753769-b9292a2d-6cf0-4269-a8e7-f12398e0de56.png)
![firefox_S7XX4qyfJe](https://user-images.githubusercontent.com/38667368/197755333-d4c740b4-2cfc-462a-85c1-e0b2ad40f4da.png)

current issue where sometimes the javascript function isn't called so that means the dropout wont work. the workaround is currently `If the groups wont drop down click <strong onclick="check_collapsibles()" style="cursor: pointer">here</strong> to fix the issue.`
